### PR TITLE
Correction de l'affichage des images dans la galerie

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,34 +1,34 @@
 // Script pour gérer la galerie d'images
 document.addEventListener('DOMContentLoaded', function() {
-    // Définir les images de la galerie (utilisation de placeholders pour le moment)
+    // Définir les images de la galerie avec des couleurs générées en CSS
     const galleryImages = [
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+1',
+            color: '#3498db', // Bleu
             title: 'Image 1',
             description: 'Description de l\'image 1'
         },
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+2',
+            color: '#2ecc71', // Vert
             title: 'Image 2',
             description: 'Description de l\'image 2'
         },
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+3',
+            color: '#e74c3c', // Rouge
             title: 'Image 3',
             description: 'Description de l\'image 3'
         },
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+4',
+            color: '#f39c12', // Orange
             title: 'Image 4',
             description: 'Description de l\'image 4'
         },
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+5',
+            color: '#9b59b6', // Violet
             title: 'Image 5',
             description: 'Description de l\'image 5'
         },
         {
-            url: 'https://via.placeholder.com/400x300?text=Image+6',
+            color: '#1abc9c', // Turquoise
             title: 'Image 6',
             description: 'Description de l\'image 6'
         }
@@ -47,11 +47,32 @@ document.addEventListener('DOMContentLoaded', function() {
             const galleryItem = document.createElement('div');
             galleryItem.className = 'gallery-item';
             
-            galleryItem.innerHTML = `
-                <img src="${image.url}" alt="${image.title}">
+            // Créer un div coloré au lieu d'une image
+            const colorBox = document.createElement('div');
+            colorBox.className = 'color-box';
+            colorBox.style.backgroundColor = image.color;
+            colorBox.style.height = '200px';
+            colorBox.style.borderRadius = '5px 5px 0 0';
+            colorBox.style.display = 'flex';
+            colorBox.style.alignItems = 'center';
+            colorBox.style.justifyContent = 'center';
+            
+            // Ajouter le titre dans la boîte colorée
+            const titleInBox = document.createElement('h3');
+            titleInBox.textContent = image.title;
+            titleInBox.style.color = 'white';
+            titleInBox.style.textShadow = '1px 1px 3px rgba(0,0,0,0.5)';
+            colorBox.appendChild(titleInBox);
+            
+            const contentDiv = document.createElement('div');
+            contentDiv.className = 'gallery-item-content';
+            contentDiv.innerHTML = `
                 <h3>${image.title}</h3>
                 <p>${image.description}</p>
             `;
+            
+            galleryItem.appendChild(colorBox);
+            galleryItem.appendChild(contentDiv);
             
             // Ajouter un événement de clic pour afficher l'image en grand
             galleryItem.addEventListener('click', function() {
@@ -68,14 +89,35 @@ document.addEventListener('DOMContentLoaded', function() {
         const modal = document.createElement('div');
         modal.className = 'modal';
         
+        // Créer la boîte colorée pour le modal
+        const modalColorBox = document.createElement('div');
+        modalColorBox.style.backgroundColor = image.color;
+        modalColorBox.style.height = '300px';
+        modalColorBox.style.borderRadius = '5px 5px 0 0';
+        modalColorBox.style.display = 'flex';
+        modalColorBox.style.alignItems = 'center';
+        modalColorBox.style.justifyContent = 'center';
+        
+        // Ajouter le titre dans la boîte colorée du modal
+        const modalTitleInBox = document.createElement('h2');
+        modalTitleInBox.textContent = image.title;
+        modalTitleInBox.style.color = 'white';
+        modalTitleInBox.style.textShadow = '1px 1px 3px rgba(0,0,0,0.5)';
+        modalColorBox.appendChild(modalTitleInBox);
+        
         modal.innerHTML = `
             <div class="modal-content">
                 <span class="close">&times;</span>
-                <img src="${image.url}" alt="${image.title}">
-                <h3>${image.title}</h3>
-                <p>${image.description}</p>
+                <div class="modal-body">
+                    <h3>${image.title}</h3>
+                    <p>${image.description}</p>
+                </div>
             </div>
         `;
+        
+        // Insérer la boîte colorée dans le modal
+        const modalContent = modal.querySelector('.modal-content');
+        modalContent.insertBefore(modalColorBox, modalContent.firstChild);
         
         // Ajouter le modal au body
         document.body.appendChild(modal);


### PR DESCRIPTION
## Problème résolu
Ce PR résout le problème d'affichage des images dans la galerie en remplaçant les images externes par des blocs de couleur générés directement via CSS. Cette approche présente plusieurs avantages :

1. Aucune dépendance aux services externes qui peuvent être indisponibles
2. Chargement plus rapide de la page
3. Apparence cohérente sur tous les appareils

## Modifications apportées
- Modification de `gallery.js` pour créer des éléments colorés au lieu de charger des images
- Ajout de styles pour ces éléments
- Adaptation du modal pour afficher correctement ces blocs de couleur

## Comment tester
1. Cloner cette branche
2. Ouvrir la page `pages/galerie.html` dans un navigateur
3. Vérifier que les blocs de couleur s'affichent correctement
4. Cliquer sur un bloc pour vérifier que le modal fonctionne

## Notes supplémentaires
Cette solution est temporaire et peut être remplacée ultérieurement par de vraies images une fois que nous aurons une solution d'hébergement d'images appropriée.